### PR TITLE
Add API key header support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ npm install
 npm start
 ```
 
+If your sources require authentication, set an `API_KEY` environment variable. The
+server will include it in an `X-API-Key` header when fetching reports.
+
 3. Visit `http://localhost:3000` for the dashboard or `http://localhost:3000/settings.html` to manage API URLs.
 
 Data sources are stored in `sources.json`.

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const { isSameWeek, isSameMonth, isSameYear } = require('date-fns');
 
 const app = express();
 const PORT = process.env.PORT || 3000;
+const API_KEY = process.env.API_KEY;
 const DATA_FILE = path.join(__dirname, 'sources.json');
 
 app.use(express.json());
@@ -63,7 +64,9 @@ app.get('/api/stats', async (req, res) => {
 
   for (const url of sources) {
     try {
-      const response = await fetch(url);
+      const response = await fetch(url, {
+        headers: API_KEY ? { 'X-API-Key': API_KEY } : undefined
+      });
       const data = await response.json();
       const reports = Array.isArray(data.reports) ? data.reports : [];
 


### PR DESCRIPTION
## Summary
- allow sending an API key with each fetch request
- document `API_KEY` environment variable usage

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6870e960368483258e43a17ca154fbfe