### PR TITLE
Center stats table in dashboard

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,7 +20,7 @@
   <div class="container">
     <div class="card shadow-sm p-4">
       <button id="refresh" class="btn btn-success btn-lg rounded-pill mb-3">تحديث التقارير</button>
-      <div id="stats" class="table-responsive"></div>
+      <div id="stats" class="table-responsive mx-auto"></div>
     </div>
   </div>
   <script src="script.js"></script>

--- a/public/styles.css
+++ b/public/styles.css
@@ -36,3 +36,20 @@ body {
     width: 100%;
   }
 }
+
+/* Center the stats table and give it a wider layout on desktops */
+#stats {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 992px) {
+  #stats {
+    width: 66%;
+  }
+}
+
+#stats table tbody tr:nth-child(even) {
+  background-color: rgba(0, 0, 0, 0.05);
+}


### PR DESCRIPTION
## Summary
- center the stats table on the page
- adjust its width to 2/3 on desktop
- alternate table row colors for clarity

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_687803ddb3e88325a7c313823b69df56