### PR TITLE
Center and widen stats table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -17,7 +17,7 @@
       </div>
     </div>
   </nav>
-  <div class="container">
+  <div class="container-fluid">
     <div class="card shadow-sm p-4">
       <button id="refresh" class="btn btn-success btn-lg rounded-pill mb-3">تحديث التقارير</button>
       <div id="stats" class="table-responsive mx-auto"></div>

--- a/public/styles.css
+++ b/public/styles.css
@@ -49,9 +49,16 @@ body {
   margin-right: auto;
 }
 
+/* Ensure the table fills the container and stays centered */
+#stats table {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 @media (min-width: 992px) {
   #stats {
-    width: 66%;
+    width: 66vw;
   }
 }
 


### PR DESCRIPTION
## Summary
- use a full width container in the dashboard
- keep the stats table centered and expand it to two-thirds of the viewport width on desktops

## Testing
- `npm start` (server started successfully)
- `curl -I http://localhost:3000`

------
https://chatgpt.com/codex/tasks/task_e_68828855842083258ecb8cbef75c61c4